### PR TITLE
Add free() to libsession wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /.vscode/
+/.vscrof/
 /node_modules/
 /*.tar.gz
 /package-lock.json

--- a/user/contacts.d.ts
+++ b/user/contacts.d.ts
@@ -6,6 +6,8 @@
 declare module 'libsession_util_nodejs' {
   type ContactsWrapper = BaseConfigWrapper & {
     init: (secretKey: Uint8Array, dump: Uint8Array | null) => void;
+    /** This function is used to free wrappers from memory only */
+    free: () => void;
     get: (pubkeyHex: string) => ContactInfo | null;
     set: (contact: ContactInfoSet) => void;
     getAll: () => Array<ContactInfo>;
@@ -55,6 +57,7 @@ declare module 'libsession_util_nodejs' {
 
   export type ContactsConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
+    | MakeActionCall<UserConfigWrapper, 'free'>
     | MakeActionCall<ContactsWrapper, 'get'>
     | MakeActionCall<ContactsWrapper, 'set'>
     | MakeActionCall<ContactsWrapper, 'getAll'>

--- a/user/contacts.d.ts
+++ b/user/contacts.d.ts
@@ -57,7 +57,7 @@ declare module 'libsession_util_nodejs' {
 
   export type ContactsConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
-    | MakeActionCall<UserConfigWrapper, 'free'>
+    | MakeActionCall<ContactsWrapper, 'free'>
     | MakeActionCall<ContactsWrapper, 'get'>
     | MakeActionCall<ContactsWrapper, 'set'>
     | MakeActionCall<ContactsWrapper, 'getAll'>

--- a/user/convovolatile.d.ts
+++ b/user/convovolatile.d.ts
@@ -14,6 +14,8 @@ declare module 'libsession_util_nodejs' {
 
   type ConvoInfoVolatileWrapper = BaseConfigWrapper & {
     init: (secretKey: Uint8Array, dump: Uint8Array | null) => void;
+    /** This function is used to free wrappers from memory only */
+    free: () => void;
 
     // 1o1 related methods
     get1o1: (pubkeyHex: string) => ConvoInfoVolatile1o1 | null;
@@ -60,6 +62,7 @@ declare module 'libsession_util_nodejs' {
 
   export type ConvoInfoVolatileConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
+    | MakeActionCall<UserConfigWrapper, 'free'>
     | MakeActionCall<ConvoInfoVolatileWrapper, 'get1o1'>
     | MakeActionCall<ConvoInfoVolatileWrapper, 'getAll1o1'>
     | MakeActionCall<ConvoInfoVolatileWrapper, 'set1o1'>

--- a/user/convovolatile.d.ts
+++ b/user/convovolatile.d.ts
@@ -62,7 +62,7 @@ declare module 'libsession_util_nodejs' {
 
   export type ConvoInfoVolatileConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
-    | MakeActionCall<UserConfigWrapper, 'free'>
+    | MakeActionCall<ConvoInfoVolatileWrapper, 'free'>
     | MakeActionCall<ConvoInfoVolatileWrapper, 'get1o1'>
     | MakeActionCall<ConvoInfoVolatileWrapper, 'getAll1o1'>
     | MakeActionCall<ConvoInfoVolatileWrapper, 'set1o1'>

--- a/user/userconfig.d.ts
+++ b/user/userconfig.d.ts
@@ -7,6 +7,8 @@ declare module 'libsession_util_nodejs' {
 
   type UserConfigWrapper = BaseConfigWrapper & {
     init: (secretKey: Uint8Array, dump: Uint8Array | null) => void;
+    /** This function is used to free wrappers from memory only */
+    free: () => void;
     getUserInfo: () => {
       name: string;
       priority: number;
@@ -49,6 +51,7 @@ declare module 'libsession_util_nodejs' {
    */
   export type UserConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
+    | MakeActionCall<UserConfigWrapper, 'free'>
     | MakeActionCall<UserConfigWrapper, 'getUserInfo'>
     | MakeActionCall<UserConfigWrapper, 'setUserInfo'>
     | MakeActionCall<UserConfigWrapper, 'getEnableBlindedMsgRequest'>

--- a/user/usergroups.d.ts
+++ b/user/usergroups.d.ts
@@ -84,7 +84,7 @@ declare module 'libsession_util_nodejs' {
 
   export type UserGroupsConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
-    | MakeActionCall<UserConfigWrapper, 'free'>
+    | MakeActionCall<UserGroupsWrapper, 'free'>
     | MakeActionCall<UserGroupsWrapper, 'getCommunityByFullUrl'>
     | MakeActionCall<UserGroupsWrapper, 'setCommunityByFullUrl'>
     | MakeActionCall<UserGroupsWrapper, 'getAllCommunities'>

--- a/user/usergroups.d.ts
+++ b/user/usergroups.d.ts
@@ -37,6 +37,8 @@ declare module 'libsession_util_nodejs' {
 
   type UserGroupsWrapper = BaseConfigWrapper & {
     init: (secretKey: Uint8Array, dump: Uint8Array | null) => void;
+    /** This function is used to free wrappers from memory only */
+    free: () => void;
 
     // Communities related methods
     /** Note: can have the pubkey argument set or not.  */
@@ -82,6 +84,7 @@ declare module 'libsession_util_nodejs' {
 
   export type UserGroupsConfigActionsType =
     | ['init', Uint8Array, Uint8Array | null]
+    | MakeActionCall<UserConfigWrapper, 'free'>
     | MakeActionCall<UserGroupsWrapper, 'getCommunityByFullUrl'>
     | MakeActionCall<UserGroupsWrapper, 'setCommunityByFullUrl'>
     | MakeActionCall<UserGroupsWrapper, 'getAllCommunities'>


### PR DESCRIPTION
`free()` clears wrappers that are stored in memory and haven't been saved to the database yet, there is no direct call to `libsession` but we want the typings